### PR TITLE
Improve catalog logging and pair validation

### DIFF
--- a/config.example.txt
+++ b/config.example.txt
@@ -1,0 +1,22 @@
+[LOGIN]
+# Insira suas credenciais no arquivo config.txt (não versionado)
+email = example@email.com
+senha = sua_senha
+
+[AJUSTES]
+tipo = automatico
+valor_entrada = 3.0
+stop_win = 50.0
+stop_loss = 70.0
+analise_medias = N
+velas_medias = 3
+tipo_par = Automático (Todos os Pares)
+
+[MARTINGALE]
+usar = S
+niveis = 1
+fator = 2.0
+
+[SOROS]
+usar = S
+niveis = 1

--- a/config.txt
+++ b/config.txt
@@ -1,6 +1,9 @@
 [LOGIN]
-email = vaniasayonara@gmail.com
-senha = Marleyj@23
+# Insira suas credenciais de login abaixo. Esta é uma amostra e deve ser
+# substituída por valores reais em um arquivo `config.txt` que não seja
+# versionado.
+email = example@email.com
+senha = sua_senha
 [AJUSTES]
 tipo = automatico
 valor_entrada = 3.0


### PR DESCRIPTION
## Summary
- filter noisy reconnect errors in catalog scripts
- ignore unsupported pairs when cataloging

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686e6b91ce548322ab0a8d52c2657636