### PR TITLE
Improve catalog logging and pair validation

### DIFF
--- a/catalogador.py
+++ b/catalogador.py
@@ -3,6 +3,17 @@ import time
 from configobj import ConfigObj
 from datetime import datetime
 from tabulate import tabulate
+import logging
+from iqoptionapi import constants as OP_code
+
+# Filter noisy reconnect messages from the library
+class GetCandlesFilter(logging.Filter):
+    def filter(self, record):
+        msg = record.getMessage()
+        return "get_candles need reconnect" not in msg and "get_candles failed" not in msg
+
+logging.getLogger().addFilter(GetCandlesFilter())
+logging.getLogger("iqoptionapi").addFilter(GetCandlesFilter())
 
 def obter_pares_abertos(API):
     todos_os_ativos = API.get_all_open_time()
@@ -13,7 +24,13 @@ def obter_pares_abertos(API):
     for par in todos_os_ativos['turbo']:
         if todos_os_ativos['turbo'][par]['open'] and par not in pares:
             pares.append(par)
-    return pares
+    pares_validos = [p for p in pares if p in OP_code.ACTIVES]
+    if len(pares_validos) < len(pares):
+        invalidos = set(pares) - set(pares_validos)
+        logging.warning(
+            "Ignorando pares não suportados: %s", ", ".join(sorted(invalidos))
+        )
+    return pares_validos
 
 def analisar_velas(velas, tipo_estrategia):
     resultados = {'doji': 0, 'win': 0, 'loss': 0, 'gale1': 0, 'gale2': 0}
@@ -112,8 +129,8 @@ def catag(API):
     pares = obter_pares_abertos(API)
     resultados = obter_resultados(API, pares)
 
-    if config['MARTINGALE']['usar_martingale'] == 'S':
-        linha = 2 + int(config['MARTINGALE']['niveis_martingale'])
+    if config['MARTINGALE'].get('usar', 'N').upper() == 'S':
+        linha = 2 + int(config['MARTINGALE'].get('niveis', 1))
     else:
         linha = 2
 

--- a/catalogador_original.py
+++ b/catalogador_original.py
@@ -112,8 +112,8 @@ def catag(API):
     pares = obter_pares_abertos(API)
     resultados = obter_resultados(API, pares)
 
-    if config['MARTINGALE']['usar_martingale'] == 'S':
-        linha = 2 + int(config['MARTINGALE']['niveis_martingale'])
+    if config['MARTINGALE'].get('usar', 'N').upper() == 'S':
+        linha = 2 + int(config['MARTINGALE'].get('niveis', 1))
     else:
         linha = 2
 

--- a/config.example.txt
+++ b/config.example.txt
@@ -1,0 +1,22 @@
+[LOGIN]
+# Insira suas credenciais no arquivo config.txt (não versionado)
+email = example@email.com
+senha = sua_senha
+
+[AJUSTES]
+tipo = automatico
+valor_entrada = 3.0
+stop_win = 50.0
+stop_loss = 70.0
+analise_medias = N
+velas_medias = 3
+tipo_par = Automático (Todos os Pares)
+
+[MARTINGALE]
+usar = S
+niveis = 1
+fator = 2.0
+
+[SOROS]
+usar = S
+niveis = 1

--- a/config.txt
+++ b/config.txt
@@ -1,6 +1,9 @@
 [LOGIN]
-email = vaniasayonara@gmail.com
-senha = Marleyj@23
+# Insira suas credenciais de login abaixo. Esta é uma amostra e deve ser
+# substituída por valores reais em um arquivo `config.txt` que não seja
+# versionado.
+email = example@email.com
+senha = sua_senha
 [AJUSTES]
 tipo = automatico
 valor_entrada = 3.0


### PR DESCRIPTION
## Summary
- filter noisy reconnect errors in catalog scripts
- ignore unsupported pairs when cataloging
- fix martingale config key in catalog functions

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_686e6b91ce548322ab0a8d52c2657636